### PR TITLE
Redesign API using generics

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,7 +14,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v2
         with:
-          go-version: 1.16
+          go-version: 1.18
       - run: ./goyek.sh
       - name: Upload coverage
         uses: actions/upload-artifact@v2
@@ -30,7 +30,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        go-version: ['1.11', '1.12', '1.13', '1.14', '1.15', '1.16']
+        go-version: [ '1.18' ]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -20,48 +20,36 @@ linters:
   enable:
     - deadcode
     - errcheck
-    - gosimple
+    # - gosimple
     - govet
     - ineffassign
-    - staticcheck
-    - structcheck
+    # - staticcheck
+    # - structcheck
     - typecheck
-    - unused
+    # - unused
     - varcheck
-    - bodyclose
     - depguard
-    - dogsled
     - dupl
     - exportloopref
     - funlen
-    - gochecknoglobals
-    - gochecknoinits
+    - gci
     - gocognit
     - goconst
     - gocritic
     - gocyclo
     - godot
-    - gofmt
     - gofumpt
-    - goimports
-    - golint
+    - revive
     - gomnd
     - goprintffuncname
     - gosec
-    - lll
-    - misspell
-    - nakedret
-    - noctx
+    - ifshort
     - nolintlint
-    - rowserrcheck
-    - sqlclosecheck
-    - stylecheck
+    # - stylecheck
+    - thelper
     - unconvert
-    - unparam
+    # - unparam
     - whitespace
-    - errorlint
-    - tparallel
-    - wrapcheck
 
 issues:
   # enable issues excluded by default 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased](https://github.com/pellared/fluentassert/compare/v0.1.0...HEAD)
 
+Redesign of the API by using generics.
+
+### Added
+
+- Add `f.OrderedAssert` and `f.OrderedRequire` which
+  operates on `constraints.Ordered` instead of `any`.
+- Add `Gt` ordered assertion that checks if `got` is greater than `want`.
+
+### Changed
+
+- Existing parameters are `any` instead of `interface{}`.
+
+### Fixed
+
+- Fix error reporting line (usage of `t.Helper()`).
+
 ## [0.1.0](https://github.com/pellared/fluentassert/releases/tag/v0.1.0) - 2021-05-11
 
 First release after the experiential phase.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ Redesign of the API by using generics.
 
 ### Changed
 
+- Require Go 1.18.
 - Existing parameters are `any` instead of `interface{}`.
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,18 +11,26 @@ Redesign of the API by using generics.
 
 ### Added
 
+- Add `f.ErrorAssert` and `f.ErrorRequire` which
+  operates on `error` instead of `any`.  
 - Add `f.OrderedAssert` and `f.OrderedRequire` which
   operates on `constraints.Ordered` instead of `any`.
+- Add `Returned` error assertion that checks if `got` is non-nil.
 - Add `Gt` ordered assertion that checks if `got` is greater than `want`.
 
 ### Changed
 
 - Require Go 1.18.
 - Existing parameters are `any` instead of `interface{}`.
+- `Nil` assertion can be used only with `f.ErrorAssert`.
 
 ### Fixed
 
 - Fix error reporting line (usage of `t.Helper()`).
+
+### Removed
+
+- `Err` assertion.
 
 ## [0.1.0](https://github.com/pellared/fluentassert/releases/tag/v0.1.0) - 2021-05-11
 

--- a/README.md
+++ b/README.md
@@ -32,22 +32,23 @@ The API takes advantage of generics to make the API more type-safe.
 ```go
 func TestFoo(t *testing.T) {
 	got, err := Foo()
-
 	f.ErrorRequire(t, err).Nil("should be no error") // works like t.Fatalf, stops execution if fails
-	f.OrderedAssert(t, got).Gt(1, "should return proper value") // works like t.Errorf, continues execution if fails
+	
+	f.Assert(t, got).Eq(1.23, "should return proper value") // works like t.Errorf, continues execution if fails
+	f.OrderedAssert(t, got).Gt(1, "should be greater than 1") // this will fail error
 }
 
 func Foo() (float64, error) {
-	return 1.23, errors.New("not implemented")
+	return 1.23, nil
 }
 ```
 
 ```sh
 $ go test
 --- FAIL: TestFoo (0.00s)
-    assert_test.go:13: should be no error
-        got: not implemented
-        want: <nil>
+    assert_test.go:14: should be greater than 1
+        got: 1.23
+        want greater than: 2
 ```
 
 ## Extensibility

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ func TestFoo(t *testing.T) {
 	f.ErrorRequire(t, err).Nil("should be no error") // works like t.Fatalf, stops execution if fails
 	
 	f.Assert(t, got).Eq(1.23, "should return proper value") // works like t.Errorf, continues execution if fails
-	f.OrderedAssert(t, got).Gt(1, "should be greater than 1") // this will fail error
+	f.OrderedAssert(t, got).Gt(1, "should be greater than 1") // this will fail
 }
 
 func Foo() (float64, error) {

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ as suggested in
 func TestFoo(t *testing.T) {
 	got, err := Foo()
 
-	f.Require(t, err).Eq(nil, "should be no error") // works like t.Fatalf, stops execution if fails
+	f.ErrorRequire(t, err).Nil("should be no error") // works like t.Fatalf, stops execution if fails
 	f.OrderedAssert(t, got).Gt(1, "should return proper value") // works like t.Errorf, continues execution if fails
 }
 

--- a/README.md
+++ b/README.md
@@ -23,6 +23,8 @@ Having a Fluent API makes it more obvious and easier to use
 as suggested in
 [Go Code Review Comments](https://github.com/golang/go/wiki/CodeReviewComments#useful-test-failures).
 
+The API takes advantage of generics to make the API more type-safe.
+
 `Star` this repository if you find it valuable and worth maintaining.
 
 ## Quick start

--- a/README.md
+++ b/README.md
@@ -31,12 +31,12 @@ as suggested in
 func TestFoo(t *testing.T) {
 	got, err := Foo()
 
-	f.Require(t, err).Nil("should be no error") // works like t.Fatalf, stops execution if fails
-	f.Assert(t, got).Eq("bar", "should return proper value") // works like t.Errorf, continues execution if fails
+	f.Require(t, err).Eq(nil, "should be no error") // works like t.Fatalf, stops execution if fails
+	f.OrderedAssert(t, got).Gt(1, "should return proper value") // works like t.Errorf, continues execution if fails
 }
 
-func Foo() (string, error) {
-	return "", errors.New("not implemented")
+func Foo() (float64, error) {
+	return 1.23, errors.New("not implemented")
 }
 ```
 

--- a/f/assert.go
+++ b/f/assert.go
@@ -3,49 +3,56 @@ package f
 
 import (
 	"github.com/pellared/fluentassert/pred"
+	"golang.org/x/exp/constraints"
 )
 
 // Assertion wraps a value to assert.
-type Assertion struct {
-	h     helperer
-	failf func(format string, args ...interface{})
-	got   interface{}
+type Assertion[T any] struct {
+	helper func()
+	failf  func(format string, args ...interface{})
+	got    T
+}
+
+// OrderedAssertion wraps an ordered value to assert.
+type OrderedAssertion[T constraints.Ordered] struct {
+	Assertion[T]
 }
 
 // Errorer reports error.
 type Errorer interface {
 	Errorf(format string, args ...interface{})
+	Helper()
 }
 
 // Fataler reports fatal error.
 type Fataler interface {
 	Fatalf(format string, args ...interface{})
+	Helper()
 }
 
 // Assert prepares an assertion which will t.Errorf if the predicate does not match.
-func Assert(t Errorer, got interface{}) Assertion {
-	h, _ := t.(helperer)
-	return Assertion{h, t.Errorf, got}
+func Assert[T any](t Errorer, got T) Assertion[T] {
+	return Assertion[T]{t.Helper, t.Errorf, got}
+}
+
+// OrderedRequire prepares an assertion which will t.Fatalf if the predicate does not match.
+func OrderedRequire[T constraints.Ordered](t Fataler, got T) OrderedAssertion[T] {
+	return OrderedAssertion[T]{Assertion: Assertion[T]{t.Helper, t.Fatalf, got}}
+}
+
+// OrderedAssert prepares an assertion which will t.Errorf if the predicate does not match.
+func OrderedAssert[T constraints.Ordered](t Errorer, got T) OrderedAssertion[T] {
+	return OrderedAssertion[T]{Assertion: Assertion[T]{t.Helper, t.Errorf, got}}
 }
 
 // Require prepares an assertion which will t.Fatalf if the predicate does not match.
-func Require(t Fataler, got interface{}) Assertion {
-	h, _ := t.(helperer)
-	return Assertion{h, t.Fatalf, got}
-}
-
-// Helper marks the calling function as a test helper function.
-// When printing file and line information, that function will be skipped.
-// Helper may be called simultaneously from multiple goroutines.
-func (a Assertion) Helper() {
-	if a.h != nil {
-		a.h.Helper()
-	}
+func Require[T any](t Fataler, got T) Assertion[T] {
+	return Assertion[T]{t.Helper, t.Fatalf, got}
 }
 
 // Should checks the given predicate.
-func (a Assertion) Should(predicate func(got interface{}) string, msg string, args ...interface{}) bool {
-	a.Helper()
+func (a Assertion[T]) Should(predicate func(got T) string, msg string, args ...interface{}) bool {
+	a.helper()
 	failMsg := predicate(a.got)
 	if failMsg == "" {
 		return true
@@ -55,35 +62,31 @@ func (a Assertion) Should(predicate func(got interface{}) string, msg string, ar
 }
 
 // Eq checks if got is equal to want.
-func (a Assertion) Eq(want interface{}, msg string, args ...interface{}) bool {
-	a.Helper()
+func (a Assertion[T]) Eq(want T, msg string, args ...interface{}) bool {
+	a.helper()
 	return a.Should(pred.Eq(want), msg, args...)
 }
 
-// Nil checks if got is nil.
-func (a Assertion) Nil(msg string, args ...interface{}) bool {
-	a.Helper()
-	return a.Should(pred.Eq(nil), msg, args...)
+// Gt checks if got is greater to want.
+func (a OrderedAssertion[T]) Gt(want T, msg string, args ...interface{}) bool {
+	a.helper()
+	return a.Should(pred.Gt(want), msg, args...)
 }
 
 // Err checks if got is an error.
-func (a Assertion) Err(msg string, args ...interface{}) bool {
-	a.Helper()
-	return a.Should(pred.Err, msg, args...)
+func (a Assertion[T]) Err(msg string, args ...interface{}) bool {
+	a.helper()
+	return a.Should(pred.Err[T], msg, args...)
 }
 
 // Panic checks if got is a function that panics when executed.
-func (a Assertion) Panic(msg string, args ...interface{}) bool {
-	a.Helper()
-	return a.Should(pred.Panic, msg, args...)
+func (a Assertion[T]) Panic(msg string, args ...interface{}) bool {
+	a.helper()
+	return a.Should(pred.Panic[T], msg, args...)
 }
 
 // NoPanic checks if got is a function that returns when executed.
-func (a Assertion) NoPanic(msg string, args ...interface{}) bool {
-	a.Helper()
-	return a.Should(pred.NoPanic, msg, args...)
-}
-
-type helperer interface {
-	Helper()
+func (a Assertion[T]) NoPanic(msg string, args ...interface{}) bool {
+	a.helper()
+	return a.Should(pred.NoPanic[T], msg, args...)
 }

--- a/f/assert_test.go
+++ b/f/assert_test.go
@@ -41,8 +41,17 @@ func TestRequireEq(t *testing.T) {
 	f.Require(t, got).Eq([]int{1, 2}, "should work with slices")
 }
 
+func TestAssertGt(t *testing.T) {
+	f.OrderedAssert(t, 3).Gt(1, "should be greater than 1")
+}
+
+func TestRequireGt(t *testing.T) {
+	f.OrderedRequire(t, 3.1).Gt(3, "should be greater than 1")
+}
+
 func TestAssertNil(t *testing.T) {
-	f.Assert(t, nil).Nil("should be nil")
+	var b []byte
+	f.Assert(t, b).Eq(nil, "should be nil")
 }
 
 func TestAssertErr(t *testing.T) {

--- a/f/assert_test.go
+++ b/f/assert_test.go
@@ -56,7 +56,12 @@ func TestAssertNil(t *testing.T) {
 
 func TestAssertErr(t *testing.T) {
 	got := errors.New("critical")
-	f.Assert(t, got).Err("should be an error")
+	f.ErrorAssert(t, got).Returned("should be an error")
+}
+
+func TestRequireNoErr(t *testing.T) {
+	var got error
+	f.ErrorRequire(t, got).Nil("should be no error")
 }
 
 func TestAssertPanic(t *testing.T) {

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,5 @@
 module github.com/pellared/fluentassert
 
-go 1.11
+go 1.18
+
+require golang.org/x/exp v0.0.0-20220318154914-8dddf5d87bd8

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,2 @@
+golang.org/x/exp v0.0.0-20220318154914-8dddf5d87bd8 h1:s/+U+w0teGzcoH2mdIlFQ6KfVKGaYpgyGdUefZrn9TU=
+golang.org/x/exp v0.0.0-20220318154914-8dddf5d87bd8/go.mod h1:lgLbSvA5ygNOMpwM/9anMpWVlVJ7Z+cHWq/eFuinpGE=

--- a/pred/predicates.go
+++ b/pred/predicates.go
@@ -29,12 +29,19 @@ func Gt[T constraints.Ordered](want T) func(got T) string {
 }
 
 // Err checks if got is an error.
-func Err[T any](got T) string {
-	var v interface{} = got
-	if _, ok := v.(error); ok {
+func Err(got error) string {
+	if got != nil {
 		return ""
 	}
 	return fmt.Sprintf("got: %+v\nwant an error", got)
+}
+
+// NoErr checks if got is nil.
+func NoErr(got error) string {
+	if got == nil {
+		return ""
+	}
+	return fmt.Sprintf("got: %+v\nwant: <nil>", got)
 }
 
 // Panic checks if got is a function that panics when executed.

--- a/pred/predicates.go
+++ b/pred/predicates.go
@@ -4,11 +4,13 @@ package pred
 import (
 	"fmt"
 	"reflect"
+
+	"golang.org/x/exp/constraints"
 )
 
 // Eq checks if got is equal to want.
-func Eq(want interface{}) func(got interface{}) string {
-	return func(got interface{}) string {
+func Eq[T any](want T) func(got T) string {
+	return func(got T) string {
 		if reflect.DeepEqual(got, want) {
 			return ""
 		}
@@ -16,17 +18,29 @@ func Eq(want interface{}) func(got interface{}) string {
 	}
 }
 
+// Gt checks if got is equal to want.
+func Gt[T constraints.Ordered](want T) func(got T) string {
+	return func(got T) string {
+		if got > want {
+			return ""
+		}
+		return fmt.Sprintf("got: %+v\nwant greater than: %+v", got, want)
+	}
+}
+
 // Err checks if got is an error.
-func Err(got interface{}) string {
-	if _, ok := got.(error); ok {
+func Err[T any](got T) string {
+	var v interface{} = got
+	if _, ok := v.(error); ok {
 		return ""
 	}
 	return fmt.Sprintf("got: %+v\nwant an error", got)
 }
 
 // Panic checks if got is a function that panics when executed.
-func Panic(got interface{}) (msg string) {
-	fn, ok := got.(func())
+func Panic[T any](got T) (msg string) {
+	var v interface{} = got
+	fn, ok := v.(func())
 	if !ok {
 		return "got: should be a func()"
 	}
@@ -40,8 +54,9 @@ func Panic(got interface{}) (msg string) {
 }
 
 // NoPanic checks if got is a function that returns when executed.
-func NoPanic(got interface{}) (msg string) {
-	fn, ok := got.(func())
+func NoPanic[T any](got T) (msg string) {
+	var v interface{} = got
+	fn, ok := v.(func())
 	if !ok {
 		return "got: should be a func()"
 	}


### PR DESCRIPTION
## Why

Take advantage of generics introduced in Go 1.18 and make the API more type-safe.

## What

- Use generics in API
- Implement `Gt` assertion (example assertion for an ordered type)
- Implement error assertions
- Fix usage of `t.Helper()`
- Remove some not needed linters and comment out the ones that are not working with Go 1.18

## TODO in next PR

- Create more motivating extensibility  example (e.g. for `http.Response`). Put them in the `examples` directory and update the docs.

## Checklist

- [x] `CHANGELOG.md` is updated.
- [x] The code changes follow [Effective Go](https://golang.org/doc/effective_go).
